### PR TITLE
Package version change

### DIFF
--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -12,7 +12,7 @@ packages:
   - glib2-devel
   - libcurl-devel
   - libxml2-devel
-  - python34-devel # CentOS specific from epel
+  - python36-devel # CentOS specific from epel
   - rpm-devel
   - openssl-devel
   - sqlite-devel


### PR DESCRIPTION
As in documentation is to use python 3.6 so updating
dependency for python36-devel in CentOS variables.

Signed-off-by: Pavel Picka <ppicka@redhat.com>