### PR TITLE
Install python3-createrepo_c on Fedora

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -11,6 +11,7 @@ packages:
   - libcurl-devel
   - libxml2-devel
   - python3-devel
+  - python3-createrepo_c
   - rpm-devel
   - openssl-devel
   - sqlite-devel


### PR DESCRIPTION
Recent versions of pulp_rpm require this.

For EL7, the tentative plan is to modify/rebuild the createrepo_c SRPM on top of the Python 3 RHEL7 software collection, and put it on Copr. Once I complete that, I'll submit another PR.