### PR TITLE
Add libmodulemd package

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -9,6 +9,7 @@ packages:
   - file-devel
   - glib2-devel
   - libcurl-devel
+  - libmodulemd
   - libxml2-devel
   - python3-devel
   - rpm-devel


### PR DESCRIPTION
To able to work with modulemd RPM plugin need to have
libmodulemd package installed.

Available only on Fedora.

re: #5072
https://pulp.plan.io/issues/5072