### PR TITLE
Add python binding for libmodule

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -12,6 +12,7 @@ packages:
   - libmodulemd
   - libxml2-devel
   - python3-devel
+  - python3-libmodulemd
   - rpm-devel
   - openssl-devel
   - sqlite-devel


### PR DESCRIPTION
Only for Fedora.

Need for pulp rpm plugin to operate with libmodulemd.

[noissue]