### PR TITLE
Fix install of createrepo_c since PyPi updated it to 0.14.3

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -9,7 +9,7 @@ packages:
   - file-devel
   - glib2-devel
   - libcurl-devel
-  - libmodulemd
+  - libmodulemd-devel
   - libxml2-devel
   - python3-devel
   - python3-libmodulemd


### PR DESCRIPTION
Tested in my containers.

createrepo_c was updated on PyPi yesterday:
https://pypi.org/project/createrepo-c/#history