### PR TITLE
Problem: Running include_roles with pulp_rpm_prerequisites causes it to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Including an example of how to use your role (for instance, with variables passe
         pulp_settings:
           secret_key: secret
         pulp_install_plugins:
-          pulp-rpm: {}
+          pulp-rpm:
+            prereq_role: "pulp-rpm-prerequisites"
       roles:
-        - pulp-rpm-prerequisites
         - pulp-database
         - pulp-workers
         - pulp-resource-manager

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,22 @@
   with_items: '{{ packages }}'
   become: true
 
+- name: Fail if we do not have prereq_pip_packages
+  fail:
+    msg:
+      - 'Error: The variable prereq_pip_packages is not defined from the pulp role.'
+      - 'You are probably running this role individually, or dynamically w/ include_role.'
+      - 'See README.md on how to set pulp_install_plugins to run it within the "pulp" role.'
+      - 'This role has completed everything else successfully. If you wish to continue,'
+      - 'you will need to pip install these packages manually:'
+      - '{{ rpm_prereq_pip_packages }}'
+  when:
+    - rpm_prereq_pip_packages is defined
+    - prereq_pip_packages is not defined
+
 - name: Merge rpm_prereq_pip_packages into prereq_pip_packages
   set_fact:
     prereq_pip_packages: "{{ prereq_pip_packages + rpm_prereq_pip_packages }}"
-  when: rpm_prereq_pip_packages is defined
+  when:
+    - rpm_prereq_pip_packages is defined
+    - prereq_pip_packages is defined


### PR DESCRIPTION
Solution: Now that we've made the main change in ansible-pulp's pulp_install_plugins variable, let's document how to properly use it here, and provide a better error message if users use it wrong.

re: #5518
Problem: Running include_roles with pulp_rpm_prerequisites causes it to fail
https://pulp.plan.io/issues/5518