### PR TITLE
add python36-gobject for CentOS 7

### DIFF
--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -3,7 +3,7 @@
 ansible_python_interpreter: /usr/bin/python
 
 packages:
-  # epel-release must be 1st so that later zchunk-devel can install from it.
+  # epel-release must be 1st so that multiple packages can install from it later.
   # And if we switch to yum or dnf, it must be a separate task.
   - epel-release
   - gcc
@@ -18,6 +18,7 @@ packages:
   - libxml2-devel
   - ninja-build
   - python36-devel # CentOS specific from epel
+  - python36-gobject # Provides 'gi' Python module
   - rpm-devel
   - openssl-devel
   - sqlite-devel


### PR DESCRIPTION
This is needed in CentOS 7 for using the `gi` library with Python 3.6.