### PR TITLE
Update for rename in more places.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-# defaults file for pulp-rpm-prerequisites
+# defaults file for pulp_rpm_prerequisites

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,2 @@
 ---
-# handlers file for pulp-rpm-prerequisites
+# handlers file for pulp_rpm_prerequisites

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for pulp-rpm-prereqs
+# tasks file for pulp_rpm_prerequisites
 
 - name: Load OS specific variables
   include_vars: '{{ ansible_distribution }}.yml'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - pulp-rpm-prerequisites
+    - pulp.pulp_rpm_prerequisites

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,5 +1,5 @@
 ---
-# vars file for pulp-rpm-prerequisites on CentOS
+# vars file for pulp_rpm_prerequisites on CentOS
 ansible_python_interpreter: /usr/bin/python
 
 packages:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,5 +1,5 @@
 ---
-# vars file for pulp-rpm-prerequisites on Fedora
+# vars file for pulp_rpm_prerequisites on Fedora
 packages:
   - gcc
   - make

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,5 +1,5 @@
 ---
-# vars file for pulp-rpm-prerequisites on Ubuntu
+# vars file for pulp_rpm_prerequisites on Ubuntu
 packages:
   - gcc
   - make

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-# vars file for pulp-rpm-prerequisites
+# vars file for pulp_rpm_prerequisites


### PR DESCRIPTION
Comments, and unused ansible test conventions.

re: #5619
pulp-rpm-prerequisites (git) and pulp.pulp_rpm_prerequisites (galaxy) are inconsistently named
https://pulp.plan.io/issues/5619

[noissue]