### PR TITLE
[WIP] Add the pulp_rpm_deps copr repo and install libcomps on EL7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,18 @@
     - ansible_distribution == "Ubuntu"
   become: true
 
+- name: Add copr repo for pulp_rpm
+  get_url:
+    url: https://copr.fedorainfracloud.org/coprs/mikedep333/pulp_rpm_deps/repo/epel-7/mikedep333-pulp_rpm_deps-epel-7.repo
+    dest: /etc/yum.repos.d/mikedep333-pulp_rpm_deps-epel-7.repo
+    mode: 0644
+    owner: root
+    group: root
+  when:
+    - ansible_distribution in ['RedHat','CentOS']
+    - ansible_distribution_major_version|int == 7
+  become: true
+
 - name: Install requested RPM packages
   package:
     name: '{{ item }}'

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -21,6 +21,7 @@ packages:
   - ninja-build
   - python36-devel
   - python36-gobject  # Provides 'gi' Python module
+  - python3-libcomps
   - rpm-devel
   - openssl-devel
   - sqlite-devel


### PR DESCRIPTION
TODO:
1. Get agreement on the copr repo approach for EL7 only.
2. Move to a pulp org (if possible) or adjust multiple-users permissions (backup plan) on the copr repo.
3. Move the github repo to the pulp org
4. Implement a dist-info file for libcomps so that pip3 knows it's installed. Many bindings RPMs do not provide one, and we often have to workaround it.