### PR TITLE
Story: As a user of pulp_rpm_prerequisites I have libcomps installed …

### DIFF
--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -29,8 +29,8 @@ packages:
   - zlib-devel
 
 # These packages must be explicitly installed during the pulp role, after the
-# venv is created. Otherwise, even though createrepo_c requires them, they are
-# often not installed, even with newer versions of pip.
+# venv is created. Otherwise, older versions of pip that lack PEP517/PEP518
+# support cannot use them to build createrepo_c or libcomps.
 rpm_prereq_pip_packages:
   - scikit-build
   - nose


### PR DESCRIPTION
…from pypi

Implementation: Now that pulp_rpm declares its dependency on libcomps
(and PyGObject), let the pip install of pulp_rpm install libcomps as a
dependency from PyPI.

The only change to this repo is to update the comments on why we must
install the build deps of scikit-build & nose, which are already
installed for createrepo_c.

fixes: #5840
as a user of pulp_rpm_prerequisites I have libcomps installed from pypi
https://pulp.plan.io/issues/5840

re: #5853
pulp_rpm does not declare its dependency on libcomps & PyGObject
https://pulp.plan.io/issues/5853