### PR TITLE
Add comment on why upgrading pip and setuptools will not help

### DIFF
--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -31,6 +31,12 @@ packages:
 # These packages must be explicitly installed during the pulp role, after the
 # venv is created. Otherwise, older versions of pip that lack PEP517/PEP518
 # support cannot use them to build createrepo_c or libcomps.
+#
+# Also note that the following replacement values do not work:
+# - pip>=19<20
+# - setuptools>=40.8<41
+# Due to this issue:
+# https://github.com/pypa/setuptools/issues/1694#issuecomment-466010982
 rpm_prereq_pip_packages:
   - scikit-build
   - nose


### PR DESCRIPTION
us handle PEP517/PEP518 build dependencies on EL7.

[noissue]