### PR TITLE
Switch Travis CI to Ubuntu 18.04 bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 sudo: required
 # By default, Traivs provides Ubuntu 14.04 VMs. We specify a newer release so
 # that Python 3.7 can be used in testing.
-dist: xenial
+dist: bionic
 services:
   - docker
 


### PR DESCRIPTION
from 16.04 xenial.

re: #5997
ansible-pulp CI should use Ubuntu 18.04 bionic
https://pulp.plan.io/issues/5997
[noissue]