### PR TITLE
Problem: pulp_use_system_wide_pkgs is often overlooked

### DIFF
--- a/.ansible-pulp_tox.sh
+++ b/.ansible-pulp_tox.sh
@@ -9,8 +9,6 @@ if [ ! -e roles/pulp.pulp_rpm_prerequisites ]; then
   ln -s $TRAVIS_BUILD_DIR roles/pulp.pulp_rpm_prerequisites
 fi
 
-sed -i 's/pulp_use_system_wide_pkgs: false/pulp_use_system_wide_pkgs: true/g' roles/pulp/defaults/main.yml
-find ./molecule/*/group_vars/all -exec sh -c "yq w -i {} pulp_use_system_wide_pkgs true" \;
 find ./molecule/*source*/group_vars/all -exec sh -c "yq w -i {} pulp_install_plugins.pulp-rpm.source_dir \/var\/lib\/pulp\/devel\/pulp_rpm" \;
 find ./molecule/*upgrade*/group_vars/all -exec sh -c "yq w -i {} pulp_install_plugins.pulp-rpm.upgrade true" \;
 find ./molecule/*/group_vars/all -exec sh -c "yq w -i {} pulp_install_plugins.pulp-rpm.prereq_role pulp.pulp_rpm_prerequisites" \;

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Here's an example playbook for using pulp_rpm_prerequisites as part of ansible-p
     - hosts: all
       vars:
         pulp_default_admin_password: password
-        pulp_use_system_wide_pkgs: true
         pulp_settings:
           secret_key: secret
         pulp_install_plugins:
@@ -41,6 +40,13 @@ Here's an example playbook for using pulp_rpm_prerequisites as part of ansible-p
         - pulp-content
       environment:
         DJANGO_SETTINGS_MODULE: pulpcore.app.settings
+
+Shared Variables:
+-----------------
+
+* `pulp_use_system_wide_pkgs`: This role sets is to `true`. See `pulp` README.
+
+* `prereq_pip_packages`: This role appends to it. See `pulp` README.
 
 License
 -------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,3 +39,10 @@
   when:
     - rpm_prereq_pip_packages is defined
     - prereq_pip_packages is defined
+
+# This puts the value of "true" into the correct scope, and makes it
+# higher priority than the pulp/defaults/. The alternative would be to
+# modify the include_roles task in ansible-pulp.
+- name: Set pulp_use_system_wide_pkgs for the pulp role
+  include_vars:
+    file: main.yml  # pulp_rpm_prerequisites/vars/main.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,7 @@
 ---
 # vars file for pulp_rpm_prerequisites
+#
+# This file gets included under tasks so that the variables are in scope for the
+# pulp role, and with higher precedence than their defaults.
+
 pulp_use_system_wide_pkgs: true


### PR DESCRIPTION
during pulp_rpm install.

Solution: Let's set it in the pulp_rpm_prerequisites role via
include_vars on the vars/main.yml

Fixes: #5992
https://pulp.plan.io/issues/5992
ansible-pulp rpm plugin: Failed building wheel for PyGObject Failed building wheel for pycairo