### PR TITLE
Problem: role metadata is incorrect or has omissions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,11 @@
 ---
 galaxy_info:
   author: Pulp Team
-  description: Support role for Pulp RPM plugin prerequisities
+  description: Support role to install the prerequisites for pulp_rpm
   company: Red Hat
   issue_tracker_url: https://pulp.plan.io/projects/pulp_rpm/issues
   license: GPL-2.0-or-later
-  min_ansible_version: 2.4
+  min_ansible_version: 2.8
   #
   # Provide a list of supported platforms, and for each platform a list of versions.
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.
@@ -20,15 +20,9 @@ galaxy_info:
     - name: EL
       versions:
         - 7
-
-  galaxy_tags: []
-  # List tags for your role here, one per line. A tag is a keyword that describes
-  # and categorizes the role. Users find roles by searching for tags. Be sure to
-  # remove the '[]' above, if you add tags to this list.
-  #
-  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-  #       Maximum 20 tags per role.
-
+  galaxy_tags:
+    - pulp
+    - pulpcore
 dependencies: []
 # List your role dependencies here, one per line. Be sure to remove the '[]' above,
 # if you add dependencies to this list.


### PR DESCRIPTION
Solution: Update it, including license string.

fixes: #6114
Fix up pulp_rpm_prerequisites role metadata, including license string
https://pulp.plan.io/issues/6114