### PR TITLE
Add swig to the RPM dependencies

### DIFF
--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -15,18 +15,20 @@ packages:
   - bzip2-devel
   - expat-devel
   - file-devel
+  - git  # libsolv bindings from github
   - glib2-devel
   - gobject-introspection-devel
   - libcurl-devel
   - libmodulemd2-devel
   - libxml2-devel
   - ninja-build
+  - openssl-devel
   - pycairo-devel
   - python36-devel
   - python36-gobject  # Provides 'gi' Python module
   - rpm-devel
-  - openssl-devel
   - sqlite-devel
+  - swig  # libsolv bindings
   - xz-devel
   - zchunk-devel
   - zlib-devel

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -7,16 +7,19 @@ packages:
   - bzip2-devel
   - expat-devel
   - file-devel
+  - git   # libsolv bindings from github
   - glib2-devel
   - libcurl-devel
   - libmodulemd-devel
   - libxml2-devel
+  - openssl-devel
   - python3-devel
   - python3-gobject  # Provides 'gi' Python module
   - python3-libmodulemd
   - rpm-devel
-  - openssl-devel
   - sqlite-devel
+  - swig   # libsolv bindings
   - xz-devel
   - zchunk-devel
   - zlib-devel
+

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -4,6 +4,7 @@ packages:
   - gcc
   - make
   - cmake
+  - git  # libsolv bindings from github
   - libbz2-dev
   - libexpat1-dev
   - libmagic-dev
@@ -16,4 +17,17 @@ packages:
   - libsqlite3-dev
   - liblzma-dev
   - libmodulemd-2.0-dev
+  - swig   # libsolv bindings
   - zlib1g-dev
+
+# These packages must be explicitly installed during the pulp role, after the
+# venv is created. Otherwise, older versions of pip that lack PEP517/PEP518
+# support cannot use them to build createrepo_c or libcomps.
+#
+# Also note that the following replacement values do not work:
+# - pip>=19<20
+# - setuptools>=40.8<41
+# Due to this issue:
+# https://github.com/pypa/setuptools/issues/1694#issuecomment-466010982
+rpm_prereq_pip_packages:
+  - scikit-build


### PR DESCRIPTION
swig is needed to generate the libsolv bindings at compile time