### PR TITLE
Adding symlink for Red Hat support

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,1 @@
+CentOS.yml


### PR DESCRIPTION
Install fails on RHEL without this in place.