### PR TITLE
pulp_rpm_prerequisites fails to install on RHEL due to missing vars file

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,1 @@
+CentOS.yml


### PR DESCRIPTION
Solution: Add symlink for Red Hat support

fixes: #6208

Thank you very much @mmyer2