### PR TITLE
Problem: pulp_rpm's need for system-wide packages conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,6 @@ Here's an example playbook for using pulp_rpm_prerequisites as part of ansible-p
       environment:
         DJANGO_SETTINGS_MODULE: pulpcore.app.settings
 
-Shared Variables:
------------------
-
-* `pulp_use_system_wide_pkgs`: This role sets is to `true`. See `pulp` README.
-
-* `prereq_pip_packages`: This role appends to it. See `pulp` README.
-
 License
 -------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,10 +49,3 @@
   when:
     - rpm_prereq_pip_packages is defined
     - prereq_pip_packages is defined
-
-# This puts the value of "true" into the correct scope, and makes it
-# higher priority than the pulp/defaults/. The alternative would be to
-# modify the include_roles task in ansible-pulp.
-- name: Set pulp_use_system_wide_pkgs for the pulp role
-  include_vars:
-    file: main.yml  # pulp_rpm_prerequisites/vars/main.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,12 +13,22 @@
     - ansible_distribution == "Ubuntu"
   become: true
 
+# Much faster than the package module at installing multiple packages
 - name: Install requested RPM packages
+  yum:
+    name: '{{ item }}'
+    state: present
+  with_items: '{{ packages }}'
+  become: true
+  when: ansible_pkg_mgr in ["yum","dnf"]
+
+- name: Install requested non-RPM packages
   package:
     name: '{{ item }}'
     state: present
   with_items: '{{ packages }}'
   become: true
+  when: ansible_pkg_mgr not in ["yum","dnf"]
 
 - name: Fail if we do not have prereq_pip_packages
   fail:

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -7,7 +7,6 @@ packages:
   # later.
   # And if we switch to yum or dnf, it must be a separate task, or different
   # looping mechanism.
-  - epel-release
   - gcc
   - make
   - cairo-gobject-devel

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -23,7 +23,6 @@ packages:
   - openssl-devel
   - pycairo-devel
   - python36-devel
-  - python36-gobject  # Provides 'gi' Python module
   - rpm-devel
   - sqlite-devel
   - xz-devel

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -3,18 +3,19 @@
 packages:
   - gcc
   - make
+  - cairo-gobject-devel
   - cmake
   - bzip2-devel
   - expat-devel
   - file-devel
   - glib2-devel
+  - gobject-introspection-devel
   - libcurl-devel
   - libmodulemd-devel
   - libxml2-devel
   - openssl-devel
+  - python3-cairo-devel
   - python3-devel
-  - python3-gobject  # Provides 'gi' Python module
-  - python3-libmodulemd
   - rpm-devel
   - sqlite-devel
   - xz-devel

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,2 @@
 ---
 # vars file for pulp_rpm_prerequisites
-#
-# This file gets included under tasks so that the variables are in scope for the
-# pulp role, and with higher precedence than their defaults.
-
-pulp_use_system_wide_pkgs: true


### PR DESCRIPTION
Problem: pulp_rpm's need for system-wide packages conflicts with having a newer version of pip

Solution: Eliminate using system-wide packages.

This partially reverts commit 14c64863c87432edd507e1f396f644231a207340.
"Problem: pulp_use_system_wide_pkgs is often overlooked"

Fixes: #6267