### PR TITLE
pulp_rpm_prerequisites CI shold test upgrading from older versions of…

### DIFF
--- a/.ansible-pulp_tox.sh
+++ b/.ansible-pulp_tox.sh
@@ -18,5 +18,7 @@ find ./molecule/*/group_vars/all -exec sh -c "echo; echo {}; cat {}" \;
 find ./molecule/*upgrade*/molecule.yml -exec sed -i '/quay.io\/pulp\/pulp-ci-dbuster:3.0.0/,+3 d' {} \;
 find ./molecule/*upgrade*/molecule.yml -exec sed -i '/debian-10/d' {} \;
 find ./molecule/*/molecule.yml -exec sed -i '/debian-10/,+3 d' {} \;
+find ./molecule/*-upgrade/molecule.yml -exec sed -i 's/pulp-ci-c7:3.0.0/pulp_rpm-ci-c7:3.1.0/g' {} \;
+find ./molecule/*-upgrade/molecule.yml -exec sed -i 's/pulp-ci-f31:3.0.0/pulp_rpm-ci-f31:3.1.0/g' {} \;
 
 tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,8 @@ jobs:
       - name: Set tox env for python 37
         if: matrix.python == '3.7'
         run: |
-          docker pull quay.io/pulp/pulp-ci-c7:3.0.0
-          docker pull quay.io/pulp/pulp-ci-f31:3.0.0
+          docker pull quay.io/pulp/pulp_rpm-ci-c7:3.1.0
+          docker pull quay.io/pulp/pulp_rpm-ci-f31:3.1.0
           echo "::set-env name=TOXENV::py37-upgrade"
       - name: Run tox
         run: ./.ansible-pulp_tox.sh


### PR DESCRIPTION
… pulp_rpm

Solution: upgrade from newly generated pulpcore 3.1.1 /
pulp_file 0.1.1 / pulp_rpm 3.1.0 / pulp_rpm_prerequisites 3.1.0 /
createrepo_c 0.15.5 images.

fixes: #6273

re: #6267
Problem: pulp_rpm's need for system-wide packages conflicts with having a newer version of pip