### PR TITLE
Revert "Temporarily force release CI tests to use pulpcore 3.2.1"

### DIFF
--- a/.pulp_installer_tox.sh
+++ b/.pulp_installer_tox.sh
@@ -14,14 +14,6 @@ if [ ! -e roles/pulp.pulp_rpm_prerequisites ]; then
   ln -s ${GITHUB_WORKSPACE:-../../pulp_rpm_prerequisites} roles/pulp.pulp_rpm_prerequisites
 fi
 
-# TEMP lines until pulp_rpm 3.3.0 is released, due to #6073 not implemented yet.
-find ./molecule/*/group_vars/all -exec sh -c "yq w -i {} pulp_version 3.2.1" \;
-#find ./molecule/*/group_vars/all -exec sh -c "yq w -i {} pulp_git_commitish 3.3.0" \;
-find ./molecule/*/group_vars/all -exec sh -c "yq w -i {} pulp_install_plugins.pulp-file.version 0.2.0 " \;
-find ./molecule/release-upgrade/group_vars/all -exec sh -c "yq d -i {} pulp_install_plugins.pulp-file.upgrade" \;
-#find ./molecule/*/group_vars/all -exec sh -c "yq w -i {} pulp_install_plugins.pulp-file.git_commitish 0.2.0 " \;
-#find ./molecule/*/group_vars/all -exec sh -c "yq d -i {} pulp_install_plugins.pulp-file" \;
-
 find ./molecule/*source*/group_vars/all -exec sh -c "yq w -i {} pulp_install_plugins.pulp-rpm.source_dir \/var\/lib\/pulp\/devel\/pulp_rpm" \;
 find ./molecule/*upgrade*/group_vars/all -exec sh -c "yq w -i {} pulp_install_plugins.pulp-rpm.upgrade true" \;
 find ./molecule/*/group_vars/all -exec sh -c "yq w -i {} pulp_install_plugins.pulp-rpm.prereq_role pulp.pulp_rpm_prerequisites" \;


### PR DESCRIPTION
This reverts commit 39da0121de2b3a96deb682a3dd9dad6e8874d6ee.

CI will fail until pulp_rpm 3.3.0 is released to PyPI. Once it is,
CI should succeed.