### PR TITLE
Update Ansible Galaxy metadata for EL8 support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,6 +20,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore


### PR DESCRIPTION
re: #6301
Add support for CentOS 8 & RHEL8 to pulp_rpm_prerequisites
https://pulp.plan.io/issues/6301

[noissue]