### PR TITLE
Problem: Our quality score on galaxy is 4

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -22,4 +22,3 @@ packages:
   - xz-devel
   - zchunk-devel
   - zlib-devel
-


### PR DESCRIPTION
out of 5 due to:
YAML_ERROR:
too many blank lines (1 > 0) (empty-lines)

Solution: Fix that error in our files that Galaxy imports.

Note: This will have to be verified manually when a new version
is released. It cannot be verified pre-release, other than by
running yamllint (which I did.)

[noissue]